### PR TITLE
@craigspaeth Add express as a dependency

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,0 +1,195 @@
+{
+  "name": "antigravity",
+  "version": "0.0.3",
+  "dependencies": {
+    "express": {
+      "version": "4.9.3",
+      "from": "express@*",
+      "resolved": "http://registry.npmjs.org/express/-/express-4.9.3.tgz",
+      "dependencies": {
+        "accepts": {
+          "version": "1.1.0",
+          "from": "accepts@~1.1.0",
+          "dependencies": {
+            "mime-types": {
+              "version": "2.0.1",
+              "from": "mime-types@~2.0.1",
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.0.1",
+                  "from": "mime-db@~1.0.1"
+                }
+              }
+            },
+            "negotiator": {
+              "version": "0.4.7",
+              "from": "negotiator@0.4.7",
+              "resolved": "http://registry.npmjs.org/negotiator/-/negotiator-0.4.7.tgz"
+            }
+          }
+        },
+        "cookie-signature": {
+          "version": "1.0.5",
+          "from": "cookie-signature@1.0.5",
+          "resolved": "http://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.5.tgz"
+        },
+        "debug": {
+          "version": "2.0.0",
+          "from": "debug@~2.0.0",
+          "dependencies": {
+            "ms": {
+              "version": "0.6.2",
+              "from": "ms@0.6.2",
+              "resolved": "http://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+            }
+          }
+        },
+        "depd": {
+          "version": "0.4.5",
+          "from": "depd@0.4.5",
+          "resolved": "http://registry.npmjs.org/depd/-/depd-0.4.5.tgz"
+        },
+        "escape-html": {
+          "version": "1.0.1",
+          "from": "escape-html@1.0.1",
+          "resolved": "http://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
+        },
+        "etag": {
+          "version": "1.3.1",
+          "from": "etag@~1.3.1",
+          "resolved": "http://registry.npmjs.org/etag/-/etag-1.3.1.tgz",
+          "dependencies": {
+            "crc": {
+              "version": "3.0.0",
+              "from": "crc@3.0.0",
+              "resolved": "http://registry.npmjs.org/crc/-/crc-3.0.0.tgz"
+            }
+          }
+        },
+        "finalhandler": {
+          "version": "0.2.0",
+          "from": "finalhandler@0.2.0",
+          "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-0.2.0.tgz"
+        },
+        "fresh": {
+          "version": "0.2.4",
+          "from": "fresh@0.2.4",
+          "resolved": "http://registry.npmjs.org/fresh/-/fresh-0.2.4.tgz"
+        },
+        "media-typer": {
+          "version": "0.3.0",
+          "from": "media-typer@0.3.0",
+          "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
+        },
+        "methods": {
+          "version": "1.1.0",
+          "from": "methods@1.1.0"
+        },
+        "on-finished": {
+          "version": "2.1.0",
+          "from": "on-finished@~2.1.0",
+          "resolved": "http://registry.npmjs.org/on-finished/-/on-finished-2.1.0.tgz",
+          "dependencies": {
+            "ee-first": {
+              "version": "1.0.5",
+              "from": "ee-first@1.0.5",
+              "resolved": "http://registry.npmjs.org/ee-first/-/ee-first-1.0.5.tgz"
+            }
+          }
+        },
+        "parseurl": {
+          "version": "1.3.0",
+          "from": "parseurl@~1.3.0"
+        },
+        "path-to-regexp": {
+          "version": "0.1.3",
+          "from": "path-to-regexp@0.1.3",
+          "resolved": "http://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.3.tgz"
+        },
+        "proxy-addr": {
+          "version": "1.0.2",
+          "from": "proxy-addr@~1.0.2",
+          "resolved": "http://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.2.tgz",
+          "dependencies": {
+            "ipaddr.js": {
+              "version": "0.1.3",
+              "from": "ipaddr.js@0.1.3",
+              "resolved": "http://registry.npmjs.org/ipaddr.js/-/ipaddr.js-0.1.3.tgz"
+            }
+          }
+        },
+        "qs": {
+          "version": "2.2.3",
+          "from": "qs@2.2.3",
+          "resolved": "http://registry.npmjs.org/qs/-/qs-2.2.3.tgz"
+        },
+        "range-parser": {
+          "version": "1.0.2",
+          "from": "range-parser@~1.0.2"
+        },
+        "send": {
+          "version": "0.9.2",
+          "from": "send@0.9.2",
+          "resolved": "http://registry.npmjs.org/send/-/send-0.9.2.tgz",
+          "dependencies": {
+            "destroy": {
+              "version": "1.0.3",
+              "from": "destroy@1.0.3",
+              "resolved": "http://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz"
+            },
+            "mime": {
+              "version": "1.2.11",
+              "from": "mime@1.2.11",
+              "resolved": "http://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+            },
+            "ms": {
+              "version": "0.6.2",
+              "from": "ms@0.6.2",
+              "resolved": "http://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+            }
+          }
+        },
+        "serve-static": {
+          "version": "1.6.2",
+          "from": "serve-static@~1.6.2",
+          "resolved": "http://registry.npmjs.org/serve-static/-/serve-static-1.6.2.tgz"
+        },
+        "type-is": {
+          "version": "1.5.1",
+          "from": "type-is@~1.5.1",
+          "dependencies": {
+            "mime-types": {
+              "version": "2.0.1",
+              "from": "mime-types@~2.0.1",
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.0.1",
+                  "from": "mime-db@~1.0.1"
+                }
+              }
+            }
+          }
+        },
+        "vary": {
+          "version": "1.0.0",
+          "from": "vary@~1.0.0"
+        },
+        "cookie": {
+          "version": "0.1.2",
+          "from": "cookie@0.1.2",
+          "resolved": "http://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz"
+        },
+        "merge-descriptors": {
+          "version": "0.0.2",
+          "from": "merge-descriptors@0.0.2",
+          "resolved": "http://registry.npmjs.org/merge-descriptors/-/merge-descriptors-0.0.2.tgz"
+        },
+        "utils-merge": {
+          "version": "1.0.0",
+          "from": "utils-merge@1.0.0",
+          "resolved": "http://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,13 +1,25 @@
 {
-  "name": "antigravity",
-  "version": "0.0.2",
-  "private": true,
-  "engines": {
-    "node": "0.10.x"
-  },
-  "devDependencies": {
-    "express": "*",
-    "underscore": "*",
-    "coffee-script": "*"
-  }
+    "name": "antigravity",
+    "version": "0.0.3",
+    "private": true,
+    "engines": {
+        "node": "0.10.x"
+    },
+    "author": {
+        "name": "Craig Spaeth",
+        "email": "craigspaeth@gmail.com",
+        "url": "http://craigspaeth.com"
+    },
+    "contributors": [{
+        "name": "Brennan Moore",
+        "email": "brennanmoore@gmail.com",
+        "url": "http://brennanmoore.com"
+    }],
+    "dependencies": {
+        "express": "*"
+    },
+    "devDependencies": {
+        "underscore": "*",
+        "coffee-script": "*"
+    }
 }


### PR DESCRIPTION
Trying to use antigravity in artsy-backbone-mixins for tests but unable to get the antigravity server running since it requires express but only as a dev dependency. We likely haven't run into this before since we have always used antigravity in projects that already have express as a dependency. 
