### PR TITLE
Move package to artsy org

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,18 +1,7 @@
 {
-  "name": "antigravity",
+  "name": "@artsy/antigravity",
   "version": "0.2.0",
-  "author": {
-    "name": "Craig Spaeth",
-    "email": "craigspaeth@gmail.com",
-    "url": "http://craigspaeth.com"
-  },
-  "contributors": [
-    {
-      "name": "Brennan Moore",
-      "email": "brennanmoore@gmail.com",
-      "url": "http://brennanmoore.com"
-    }
-  ],
+  "author": "Art.sy Inc <it@artsymail.com>",
   "dependencies": {
     "express": "4.17.1",
     "lodash": "4.17.15",


### PR DESCRIPTION
Can't publish this ATM, renaming as `@artsy/antigravity` and adding `it@artsymail.com` as author.